### PR TITLE
Adding an option execOpts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Default value: `'src'`
 
 A string value that is used to specify the output path of the export.
 
+#### options.execOpts
+Type: `Object`
+Default value: `{}`
+
+An object with exec configuration settings
+
 ### Usage Examples
 
 #### Default Options
@@ -66,6 +72,10 @@ grunt.initConfig({
     dev: {
       options: {
         repository: 'file:///some/repo/path'
+        // Optional setting for exporting large repositories
+        execOpts: {
+          maxBuffer: 1000*1024
+        }        
       }
     }
   }

--- a/tasks/svn_export.js
+++ b/tasks/svn_export.js
@@ -18,7 +18,8 @@ module.exports = function(grunt) {
     var options = this.options({
       bin:        'svn',
       repository: '',
-      output:     'src'
+      output:     'src',
+      execOpts:	  {}
     });
     grunt.verbose.writeflags(options, 'Options');
     grunt.log.write('Exporting from ' + options.repository + '\n');
@@ -26,7 +27,7 @@ module.exports = function(grunt) {
     var done = this.async();
     var command = [ options.bin, 'export', options.repository, options.output ].join(' ');
 
-    exec(command, function (error, stdout) {
+    exec(command, options.execOpts, function (error, stdout) {
       grunt.log.write(stdout);
       if (error !== null) {
         grunt.log.error('\n#' + command + "\n" + error);


### PR DESCRIPTION
Solving the issue "Error: stdout maxBuffer exceeded" when exporting big repositories: https://github.com/francisbyrne/grunt-svn-export/issues/1

The option execOpts is also used in other gruntjs plugins. For example https://github.com/rma4ok/grunt-bg-shell
